### PR TITLE
Accept .hocr instead of .html

### DIFF
--- a/02-createpdf.sh
+++ b/02-createpdf.sh
@@ -53,7 +53,7 @@ echo 'doing OCR...'
 for i in scan_*.pnm.tif; do
     echo "${i}"
     tesseract "$i" "$i" -l $LANGUAGE hocr
-    hocr2pdf -i "$i" -s -o "$i.pdf" < "$i.html"
+    hocr2pdf -i "$i" -s -o "$i.pdf" < "$i.hocr"
 done
 
 # create PDF


### PR DESCRIPTION
It looks like newer versions of tesseract create .hocr files instead of .html ones. They even overlook this on the example scripts on their website.
